### PR TITLE
Use supported ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:18.04
 
 MAINTAINER Florian Benz
 


### PR DESCRIPTION
I came across this image while trying to avoid writing these three lines of Dockerfile myself, but sadly the Ubuntu base version is so old that the package indexes are no longer available. This is an easy fix, I can confirm it works on the latest version.